### PR TITLE
Try to cleanup vendor type-id messaging (Monkooky)

### DIFF
--- a/crawl-ref/source/acquire.cc
+++ b/crawl-ref/source/acquire.cc
@@ -1610,7 +1610,7 @@ AcquireMenu::AcquireMenu(CrawlVector &aitems, string ikey,
 }
 
 static void _create_acquirement_item(item_def &item, string items_key,
-                                     bool is_gizmo = false)
+                                     bool is_gizmo = false, bool is_vendor = false)
 {
     auto &acq_items = you.props[items_key].get_vector();
 
@@ -1632,6 +1632,10 @@ static void _create_acquirement_item(item_def &item, string items_key,
     // Mark as seen so that Lucky cannot proc off it.
     item.flags |= (ISFLAG_NOTED_ID | ISFLAG_NOTED_GET | ISFLAG_SEEN);
     identify_item(item);
+
+    // Prevent repetitive post-acq type-id messages from vendors
+    if (is_vendor)
+        seen_item(item, false);
 
     if (is_gizmo)
     {
@@ -1690,7 +1694,7 @@ void AcquireMenu::init_entries()
         }
 
         item_def &acq_item = *static_cast<item_def*>(item.data);
-        _create_acquirement_item(acq_item, key, is_gizmo);
+        _create_acquirement_item(acq_item, key, is_gizmo, is_vendor);
 
         return false;
     };

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -3273,7 +3273,7 @@ weapon_type name_nospace_to_weapon(string name_nospace)
     return WPN_UNKNOWN;
 }
 
-void seen_item(item_def &item)
+void seen_item(item_def &item, bool announce)
 {
     if (!is_artefact(item) && _is_affordable(item))
     {
@@ -3306,7 +3306,8 @@ void seen_item(item_def &item)
         for (int i = MAX_GEAR; i < ENDOFPACK; ++i)
         {
             if (you.inv[i].base_type == item.base_type
-                && you.inv[i].sub_type == item.sub_type)
+                && you.inv[i].sub_type == item.sub_type
+                && announce)
             {
                 held = &you.inv[i];
                 mprf("You learned that %s %s actually %s.",

--- a/crawl-ref/source/item-prop.h
+++ b/crawl-ref/source/item-prop.h
@@ -277,7 +277,7 @@ bool item_known_excluded_from_set(object_class_type type, int sub_type);
 item_set_type item_set_by_name(string name);
 string item_name_for_set(item_set_type typ);
 
-void seen_item(item_def &item);
+void seen_item(item_def &item, bool announce = true);
 
 static inline bool is_weapon(const item_def &item)
 {


### PR DESCRIPTION
Previously, vendor acquirements of items with type-ids would output a repetitive "You learned that your 3 scrolls of silence are actually 3 scrolls of silence." message to the log.

Here we run seen_item() immediately upon acquiring a vendor item, with squelched type-id messaging, to hopefully handle these post- purchase messages for vendor items with type-id a little more gracefully.